### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Sensors
 
 ### TelegramSensor

--- a/actions/send_message.yaml
+++ b/actions/send_message.yaml
@@ -1,6 +1,6 @@
 ---
   name: "send_message"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "send a message to a user or group"
   enabled: true
   entry_point: "send_message.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ description : Telegram integration pack for Stack Storm
 keywords:
   - telegram
   - messaging
-version : 0.1.0
+version : 0.2.0
 author : Fabio Brito
 email : psychopenguin@gmail.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.