### PR TITLE
Bump urllib3 version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-# 0.2.0
+## 0.2.2
+
+- Bump `urllib3` to `1.2.3` due to security vulnerability (CVE-2018-20060)
+
+## 0.2.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,9 +1,9 @@
 ---
 name : telegram
-description : Telegram integration pack for Stack Storm
+description : Telegram Messaging integration
 keywords:
   - telegram
   - messaging
-version: 0.2.1
+version: 0.2.2
 author : Fabio Brito
 email : psychopenguin@gmail.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ packaging==16.8
 pyparsing==2.2.0
 python-telegram-bot==5.3.0
 six==1.10.0
-urllib3==1.20
+urllib3==1.23


### PR DESCRIPTION
Bump `urllib3` version due to CVE-2018-20060.

Better long-term change would be to bump version of `python-telegram-bot` to >= v11.1.0, which no longer requires urllib3.

The `requirements.txt` in this pack probably doesn't need all the dependencies listed. They should get pulled in when python-telegram-bot gets installed.
