### PR TITLE
feat: add support for html parse mode

### DIFF
--- a/actions/send_message.py
+++ b/actions/send_message.py
@@ -7,5 +7,6 @@ from st2common.runners.base_action import Action
 class TelegramSendMessageAction(Action):
     def run(self, message, chat_id):
         bot = telegram.Bot(token=self.config['apikey'])
-        m = bot.sendMessage(text=emojize(message, use_aliases=True), chat_id=chat_id)
+        m = bot.sendMessage(text=emojize(message, use_aliases=True), chat_id=chat_id,
+                            parse_mode=telegram.ParseMode.HTML)
         return m


### PR DESCRIPTION
Added support for bot.sendMessage() parse_mode with HTML. For more information read documentation: [telegram-api](https://core.telegram.org/bots/api#formatting-options)

P.S 
If python-telegram-bot upgrade to latest version, we can use MarkdownV2, it's better!

